### PR TITLE
Fix world failing to save on Windows (illegal ':' in SavedData filename)

### DIFF
--- a/src/main/java/com/lothrazar/creeperheal/worldhealer/WorldHealerSaveDataSupplier.java
+++ b/src/main/java/com/lothrazar/creeperheal/worldhealer/WorldHealerSaveDataSupplier.java
@@ -34,7 +34,7 @@ public class WorldHealerSaveDataSupplier extends SavedData implements Supplier<O
 
   private Level level;
   private TickingHealList healTask;
-  static final String DATAKEY = ForgeCreeperHeal.MODID + ":" + WorldHealerSaveDataSupplier.class.getSimpleName();
+  static final String DATAKEY = ForgeCreeperHeal.MODID + "_" + WorldHealerSaveDataSupplier.class.getSimpleName();
 
   public WorldHealerSaveDataSupplier() {
     healTask = new TickingHealList();


### PR DESCRIPTION
Fixes #19.

`DATAKEY` is built as `creeperheal:WorldHealerSaveDataSupplier` and is used directly as the `SavedData` filename. On Windows the `:` is an illegal path character, so the world's final save on exit throws `InvalidPathException`, which aborts server shutdown and leaves `session.lock` held — the world then shows as unavailable in the singleplayer list until the game is fully restarted. (Linux/macOS are unaffected since `:` is legal there.)

This swaps the `:` separator for `_`, making the data id filesystem-safe on all platforms. One-line change; heal-queue data is transient so there is no meaningful migration concern.

Verified against MC 1.21.1 / NeoForge / CreeperHeal 2.0.3.